### PR TITLE
Pull copy of remote storage db

### DIFF
--- a/coiled_calib.py
+++ b/coiled_calib.py
@@ -33,14 +33,13 @@ class CoiledCalibration(ss.Calibration):
         self.run_args.update(kwargs)  # Update optuna settings
 
         with coiled.Cluster(
-                n_workers=1,
-                name='StarsimCalibrationOnCoiled',
+            n_workers=1,
+            name='StarsimCalibrationOnCoiled',
         ) as cluster:
         # with LocalCluster(processes=False, n_workers=4) as cluster:
             with cluster.get_client() as client:
                 # Run the optimization
                 t0 = sc.tic()
-                backend_storage = op.storages.InMemoryStorage()
                 self.run_args.storage = op.integration.DaskStorage(storage=f'sqlite:///{self.run_args.db_name}',
                                                                    client=client)
                 self.study = self.make_study()
@@ -91,6 +90,23 @@ class CoiledCalibration(ss.Calibration):
                 self.parse_study(study)
 
                 if self.verbose: print('Best pars:', self.best_pars)
+
+                # Retrieve study db data from remote Dask cluster and save results to a local file.
+                # This let's us continue to have study results after the cluster is shut down.
+                def get_db_data():
+                    with open(f"/opt/coiled/{self.run_args.db_name}", "rb") as f:
+                        data = f.read()
+                        return data
+
+                db_data = client.run_on_scheduler(get_db_data)
+                with open(self.run_args.db_name, "wb") as f:
+                    f.write(db_data)
+
+                # Reload study with local file for future use
+                self.run_args.storage = f"sqlite:///{self.run_args.db_name}"
+                self.study = op.load_study(storage=self.run_args.storage,
+                                      study_name=self.run_args.study_name,
+                                      sampler=self.run_args.sampler)
 
                 # Tidy up
                 self.calibrated = True


### PR DESCRIPTION
@pausz this PR adds a few lines to make a local copy of the sqlite db that's stored on the remote Dask cluster. With the changes here I'm able to run `python coiled_calib.py` locally (i.e. the plotting code at the end doesn't error). 

I should note that there's a `DaskStorage.get_base_storage()` method that's supposed to do this automatically. It works well when using in-memory storage with Optuna, but isn't working with the sqlite backend. I've opened up this issue upstream https://github.com/optuna/optuna-integration/issues/211 

We also discussed mounting an S3 bucket on the cluster on our last call. That would be another approach that could be taken here -- use S3 for persisting study results. 